### PR TITLE
GA4 이벤트/퍼널 로깅 추가

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,25 @@
 
 ---
 
+## 📈 Google Analytics (GA4)
+
+Renderer(웹)에서 GA4를 사용하려면 `.env`에 아래 값을 추가하세요.
+
+```bash
+VITE_GA_MEASUREMENT_ID=G-XXXXXXXXXX
+```
+
+- 기본적으로 프로덕션 빌드(`import.meta.env.PROD`)에서만 초기화됩니다.
+- 로컬에서 확인이 필요하면 개발 환경에서만 아래 값을 추가해 활성화할 수 있습니다.
+
+```bash
+VITE_GA_ENABLE_IN_DEV=true
+```
+
+- React Router 경로 변경마다 `page_view` 이벤트를 전송합니다.
+
+---
+
 ## 📁 프로젝트 구조
 
 Electron 프로젝트는 일반적으로 **Main Process**, **Preload Scripts**, **Renderer Process** 세 가지 프로세스로 구성됩니다. 이 프로젝트는 Vite를 사용하여 각 프로세스를 독립적으로 빌드하고, TypeScript와 React를 활용한 구조로 설계되었습니다.

--- a/ga.md
+++ b/ga.md
@@ -1,0 +1,20 @@
+name affectsfunnel affectretention category description ga등록여부 metricpurpose notes parameters qachecked requiredparams screen sessionidrequried status trigger useridrequired userscope
+
+download_click Yes No 퍼널 설치 페이지에서 사용자가 다운로드 버튼을 클릭한 행동을 추적하는 이벤트 No 유입 채널 및 OS별 다운로드 전환율을 분석하여 마케팅 효율과 초기 서비스 관심도를 측정 platform: string (mac | windows),
+source: string (landing | blog | ad) No platform,source download No Ready 설치 페이지 내 다운로드 버튼 클릭 시 No anonymous
+sign_up_complete Yes Yes 퍼널 사용자가 회원가입 프로세스를 끝까지 완료하여 서비스 이용이 가능한 상태가 되었음을 나타내는 이벤트 No 가입 전환율 측정 및 이후 리텐션·코호트 분석의 기준점(anchor) 설정 user_id: string No user_id email_verify No Ready 회원가입 메일 확인 클릭 시 Yes logged_in
+onboarding_enter Yes No 퍼널 회원가입 이후 사용자가 초기 설정을 진행하기 위해 온보딩 플로우에 진입했음을 나타내는 이벤트 No 온보딩 진입률을 기준으로 초기 설정 단계에서의 이탈 여부 및 병목 구간을 분석 step: string (posture_calibration) No step onboarding No Ready 회원가입 완료 후 온보딩 화면 최초 진입 시 Yes logged_in
+measure_page_enter Yes No 퍼널 사용자가 실제 자세 측정을 시작하기 위해 메인 측정 페이지에 진입했음을 나타내는 이벤트 No 가입 및 온보딩 이후 핵심 기능(측정)까지 도달한 유저 비율 session_id: string, No session_id main Yes Ready 메인 화면으로 최초 진입 시 Yes logged_in
+first_measure_start Yes No 퍼널 회원가입 완료 시점부터 사용자가 처음으로 자세 측정을 시작하기까지 소요된 시간을 기록하는 이벤트 No 가입 이후 사용자가 핵심 가치(AHA Moment)에 도달하는 데 걸리는 시간 분포를 분석하여 온보딩 효율성과 초기 경험 품질을 평가 seconds_from_signup: number No seconds_from_signup main No Ready 사용자의 첫 측정 Start 버튼 클릭 시 Yes logged_in
+measure_start No No 활성 사용자가 자세 측정을 실제로 시작했음을 나타내는 이벤트 No 유저별 측정 시작 빈도 및 활성 사용 여부(DAU 대비 실제 사용률) 분석 하나의 측정 흐름을 식별하기 위해 measure_end 이벤트와 동일한 session_id를 사용 session_id: string No session_id main Yes Ready 측정 Start 버튼 클릭 시 Yes logged_in
+measure_end No No 활성 사용자가 진행 중이던 자세 측정을 종료했음을 나타내는 이벤트 No 유저별 단일 측정 시간과 전체 서비스 이용 시간 합산을 통한 활동량 분석 duration_sec는 측정 시작 시각과 종료 시각을 클라이언트에서 계산하여 전송하며, 비정상 종료(앱 종료 등)는 별도 케이스로 처리 가능 session_id: string,
+duration_sec: number No duration_sec,session_id main Yes Ready 측정 Stop 버튼 클릭 또는 측정 자동 종료 시 Yes logged_in
+bad_posture_enter No No 핵심 자세가 임계치를 벗어나 거북이 상태로 진입했음을 나타내는 이벤트 No 유저별 자세 심각도 분포 분석 및 세션/유저 단위 문제 발생 총량 파악 session_id: string, posture_level: number No session_id main Yes Ready 정상 또는 기린 상태에서 거북이 레벨(1|2|3)로 최초 전이되는 시점 Yes logged_in
+posture_recovered No No 핵심 거북이 상태에서 정상(기린) 자세로 복원되었음을 나타내는 이벤트 No 교정 성공률 산출 및 전체 유저 평균 복원 소요 시간으로 교정 실효성 증명 recovery_time_sec: number, posture_level: number, session_id: string No session_id main Yes Ready 거북이 상태 이후 기린 레벨(4|5|6)로 전이되는 시점 Yes logged_in
+widget_toggle No No 위젯 사용자가 자세 교정 위젯을 활성화하거나 비활성화했음을 나타내는 이벤트
+Trigger: 위젯 On/Off 토글 스위치 변경 시 No 사용자가 자세 교정 위젯을 활성화하거나 비활성화했음을 나타내는 이벤트 enabled: boolean (true | false) No enabled widget No Ready 위젯 On/Off 토글 스위치 변경 시 Yes logged_in
+widget_visibility_end No No 위젯 활성화된 위젯이 화면에서 노출되었다가 사라질 때까지의 지속 시간을 기록하는 이벤트 No 위젯 실제 노출 시간을 기반으로 자발적 교정 행동의 강도와 위젯 방식의 실효성을 평가 duration_sec: number,
+session_id: string (optional) No duration_sec widget No Ready 위젯이 비활성화되거나 화면에서 제거되는 시점 Yes logged_in
+notification_toggle No No 알림 사용자가 자세 교정 알림 기능을 활성화하거나 비활성화했음을 나타내는 이벤트 No 알림 기반 교정 방식과 위젯 기반 교정 방식에 대한 유저 선호도를 분류하고, 교정 행동 유도 방식의 효과를 비교 분석 enabled: boolean (true | false) No enabled settings No Ready 알림 설정 화면 또는 토글 스위치에서 알림 On/Off 변경 시 Yes logged_in
+app_open No Yes 잔존 회원가입 후 7일 시점에 사용자가 앱을 다시 실행했는지를 기준으로 측정하는 리텐션 지표 No 가입 후 7일 이내 서비스에 재방문한 유저 비율을 측정하여 전체 서비스의 기본 존속성(rolling retention)을 파악 GA4 기본 app_open 이벤트를 사용하며, 별도 커스텀 이벤트는 생성하지 않고 탐색(Explore)에서 Day 7 기준으로 분석 No app No Ready 앱 실행 시 Yes logged_in
+meaningful_use No Yes 잔존 회원가입 후 7일 시점에 사용자가 실제로 핵심 기능(자세 측정)을 수행했는지를 기준으로 측정하는 진성 리텐션 지표 No 단순 재접속이 아닌 실제 가치 행동을 기준으로 한 진성 유저 잔존율을 측정하여 PMF 여부를 판단 measure_start 이벤트를 리텐션 기준으로 직접 사용해도 되며, 분석 명확성을 위해 별도의 의미적 이벤트(meaningful_use)로 추상화 가능 type: string (measure_start) No type main No Ready 측정 Start 버튼 클릭 시 (7일 이후) Yes logged_in

--- a/src/renderer/src/app/providers/App.tsx
+++ b/src/renderer/src/app/providers/App.tsx
@@ -1,11 +1,46 @@
 import { router } from '@shared/config/router';
+import { initGA4, trackPageView } from '@shared/lib/analytics/ga4';
 import { LoadingSpinner } from '@shared/ui/loading';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { Suspense } from 'react';
+import { Suspense, useEffect, useRef } from 'react';
 import { RouterProvider } from 'react-router-dom';
 
 function App() {
   const queryClient = new QueryClient();
+  const lastPathRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    const measurementId = import.meta.env.VITE_GA_MEASUREMENT_ID;
+    if (!measurementId) return;
+
+    const enabled =
+      import.meta.env.PROD || import.meta.env.VITE_GA_ENABLE_IN_DEV === 'true';
+    if (!enabled) return;
+
+    initGA4(measurementId, { debug_mode: !import.meta.env.PROD });
+
+    const toPath = (loc: { pathname?: string; search?: string; hash?: string }) =>
+      `${loc.pathname ?? ''}${loc.search ?? ''}${loc.hash ?? ''}` || '/';
+
+    const send = (loc: { pathname: string; search: string; hash: string }) => {
+      const path = toPath(loc);
+      if (lastPathRef.current === path) return;
+      lastPathRef.current = path;
+
+      trackPageView({
+        page_path: path,
+        page_title: document.title,
+      });
+    };
+
+    // initial
+    send(router.state.location);
+
+    // navigation changes
+    return router.subscribe((state) => {
+      send(state.location);
+    });
+  }, []);
 
   return (
     <QueryClientProvider client={queryClient}>

--- a/src/renderer/src/app/providers/App.tsx
+++ b/src/renderer/src/app/providers/App.tsx
@@ -1,5 +1,5 @@
 import { router } from '@shared/config/router';
-import { initGA4, trackPageView } from '@shared/lib/analytics/ga4';
+import { initGA4, setGAUserId, trackPageView } from '@shared/lib/analytics/ga4';
 import { LoadingSpinner } from '@shared/ui/loading';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { Suspense, useEffect, useRef } from 'react';
@@ -18,6 +18,8 @@ function App() {
     if (!enabled) return;
 
     initGA4(measurementId, { debug_mode: !import.meta.env.PROD });
+    const storedUserId = localStorage.getItem('userId');
+    if (storedUserId) setGAUserId(storedUserId);
 
     const toPath = (loc: { pathname?: string; search?: string; hash?: string }) =>
       `${loc.pathname ?? ''}${loc.search ?? ''}${loc.hash ?? ''}` || '/';

--- a/src/renderer/src/entities/session/api/use-create-session-mutation.ts
+++ b/src/renderer/src/entities/session/api/use-create-session-mutation.ts
@@ -40,6 +40,7 @@ export const useCreateSessionMutation = () => {
 
       const signupCompletedAtRaw = localStorage.getItem('signupCompletedAt');
       const firstMeasureSent = localStorage.getItem('ga_first_measure_start_sent');
+      const meaningfulUseSent = localStorage.getItem('ga_meaningful_use_sent');
       if (signupCompletedAtRaw && firstMeasureSent !== 'true') {
         const signupCompletedAt = Number(signupCompletedAtRaw);
         if (Number.isFinite(signupCompletedAt) && signupCompletedAt > 0) {
@@ -49,6 +50,17 @@ export const useCreateSessionMutation = () => {
           );
           AnalyticsEvents.firstMeasureStart({ seconds_from_signup });
           localStorage.setItem('ga_first_measure_start_sent', 'true');
+        }
+      }
+
+      if (signupCompletedAtRaw && meaningfulUseSent !== 'true') {
+        const signupCompletedAt = Number(signupCompletedAtRaw);
+        if (Number.isFinite(signupCompletedAt) && signupCompletedAt > 0) {
+          const sevenDaysMs = 7 * 24 * 60 * 60 * 1000;
+          if (Date.now() - signupCompletedAt >= sevenDaysMs) {
+            AnalyticsEvents.meaningfulUse({ type: 'measure_start' });
+            localStorage.setItem('ga_meaningful_use_sent', 'true');
+          }
         }
       }
     },

--- a/src/renderer/src/entities/user/api/use-signup-mutation.ts
+++ b/src/renderer/src/entities/user/api/use-signup-mutation.ts
@@ -2,6 +2,7 @@ import api from '@shared/api';
 import { useMutation } from '@tanstack/react-query';
 import { useNavigate } from 'react-router-dom';
 import { SignupRequest } from '../types';
+import axios from 'axios';
 
 /* 이메일 중복 확인 api */
 const duplicatedEmail = async (email: string) => {
@@ -24,20 +25,12 @@ const signupUser = async (data: SignupRequest) => {
     }
 
     return response.data;
-  } catch (error: any) {
-    // axios 에러인 경우 response.data에서 메시지 추출
-    if (error.response?.data?.message) {
-      throw new Error(error.response.data.message);
-    }
-    if (error.response?.data) {
-      const errorData = error.response.data;
+  } catch (error: unknown) {
+    if (axios.isAxiosError(error) && error.response?.data) {
+      const errorData = error.response.data as { message?: string; code?: string };
       throw new Error(errorData.message || errorData.code || '회원가입 실패');
     }
-    // 일반 에러인 경우
-    if (error instanceof Error) {
-      throw error;
-    }
-    throw new Error('회원가입 실패');
+    throw error instanceof Error ? error : new Error('회원가입 실패');
   }
 };
 

--- a/src/renderer/src/entities/user/api/use-verify-email-mutation.ts
+++ b/src/renderer/src/entities/user/api/use-verify-email-mutation.ts
@@ -2,30 +2,38 @@ import { useMutation } from '@tanstack/react-query';
 import { useNavigate } from 'react-router-dom';
 import api from '@shared/api';
 import { ResendVerifyEmailRequest } from '../types';
+import { AnalyticsEvents } from '@shared/lib/analytics/events';
+import axios from 'axios';
+
+type VerifyEmailResponse = {
+  success: boolean;
+  code?: string;
+  message?: string | null;
+  data?: {
+    id?: string;
+    userId?: string;
+  };
+};
 
 /*이메일 인증 api*/
 const verifyEmail = async (token: string) => {
   try {
-    const response = await api.post('/auth/verify-email', { token });
-    const result = response.data;
+    const response = await api.post<VerifyEmailResponse>('/auth/verify-email', {
+      token,
+    });
+    const result = response.data as VerifyEmailResponse;
 
     if (!result.success) {
       throw new Error(result.message || '인증 실패');
     }
 
     return response.data;
-  } catch (error: any) {
-    if (error.response?.data?.message) {
-      throw new Error(error.response.data.message);
-    }
-    if (error.response?.data) {
-      const errorData = error.response.data;
+  } catch (error: unknown) {
+    if (axios.isAxiosError(error) && error.response?.data) {
+      const errorData = error.response.data as { message?: string; code?: string };
       throw new Error(errorData.message || errorData.code || '인증 실패');
     }
-    if (error instanceof Error) {
-      throw error;
-    }
-    throw new Error('인증 실패');
+    throw error instanceof Error ? error : new Error('인증 실패');
   }
 };
 
@@ -44,20 +52,12 @@ const resendVerifyEmail = async (data: ResendVerifyEmailRequest) => {
     }
 
     return response.data;
-  } catch (error: any) {
-    if (error.response?.data?.message) {
-      throw new Error(error.response.data.message);
+  } catch (error: unknown) {
+    if (axios.isAxiosError(error) && error.response?.data) {
+      const errorData = error.response.data as { message?: string; code?: string };
+      throw new Error(errorData.message || errorData.code || '다시 보내기 실패');
     }
-    if (error.response?.data) {
-      const errorData = error.response.data;
-      throw new Error(
-        errorData.message || errorData.code || '다시 보내기 실패',
-      );
-    }
-    if (error instanceof Error) {
-      throw error;
-    }
-    throw new Error('다시 보내기 실패');
+    throw error instanceof Error ? error : new Error('다시 보내기 실패');
   }
 };
 
@@ -67,6 +67,12 @@ export const useVerifyEmailMutation = () => {
 
     onSuccess: (data) => {
       console.log('이메일 인증 성공:', data);
+      const userId =
+        (data as VerifyEmailResponse | undefined)?.data?.userId ??
+        (data as VerifyEmailResponse | undefined)?.data?.id;
+
+      AnalyticsEvents.signUpComplete({ user_id: userId });
+
       alert('인증 성공!');
       localStorage.clear();
     },

--- a/src/renderer/src/features/notification/ui/NotificationModal.tsx
+++ b/src/renderer/src/features/notification/ui/NotificationModal.tsx
@@ -4,6 +4,7 @@ import { useTimeEditor } from './hooks/useTimeEditor';
 import { TimeControlSection } from './components/TimeControlSection';
 import { Button } from '@shared/ui/button';
 import { useNotificationStore } from '../model/use-notification-store';
+import { AnalyticsEvents } from '@shared/lib/analytics/events';
 
 interface NotificationModalProps {
   onClose: () => void;
@@ -35,6 +36,10 @@ const NotificationModal = ({ onClose }: NotificationModalProps) => {
 
   /* 저장하기 핸들러 - 알림 허용, 스트레칭, 거북목 시간 간격 전역 저장 */
   const handleSave = async () => {
+    if (store.isAllow !== isAllow) {
+      AnalyticsEvents.notificationToggle({ enabled: isAllow });
+    }
+
     store.setSettings({
       isAllow,
       stretching: {

--- a/src/renderer/src/pages/onboarding-init-page/index.tsx
+++ b/src/renderer/src/pages/onboarding-init-page/index.tsx
@@ -1,12 +1,17 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import ImageDescriptionPannel from '../onboarding-page/components/ImageDescriptionPanel';
 import InfoPanel from '../onboarding-page/components/InfoPanel';
+import { AnalyticsEvents } from '@shared/lib/analytics/events';
 
 const OnboardinInitPage = () => {
   const navigate = useNavigate();
   const [currentStep, setCurrentStep] = useState(1);
   const [direction, setDirection] = useState<'next' | 'prev'>('next');
+
+  useEffect(() => {
+    AnalyticsEvents.onboardingEnter({ step: 'posture_calibration' });
+  }, []);
 
   const handlePrev = () => {
     if (currentStep > 1) {

--- a/src/renderer/src/shared/lib/analytics/events.ts
+++ b/src/renderer/src/shared/lib/analytics/events.ts
@@ -1,0 +1,46 @@
+import { trackEvent } from './ga4';
+
+export const AnalyticsEvents = {
+  downloadClick: (params: { platform: 'mac' | 'windows'; source: string }) =>
+    trackEvent('download_click', params),
+
+  signUpComplete: (params: { user_id?: string }) =>
+    trackEvent('sign_up_complete', params),
+
+  onboardingEnter: (params: { step: string }) =>
+    trackEvent('onboarding_enter', params),
+
+  measurePageEnter: (params: { session_id: string }) =>
+    trackEvent('measure_page_enter', params),
+
+  firstMeasureStart: (params: { seconds_from_signup: number }) =>
+    trackEvent('first_measure_start', params),
+
+  measureStart: (params: { session_id: string }) =>
+    trackEvent('measure_start', params),
+
+  measureEnd: (params: { session_id: string; duration_sec: number }) =>
+    trackEvent('measure_end', params),
+
+  badPostureEnter: (params: { session_id: string; posture_level: number }) =>
+    trackEvent('bad_posture_enter', params),
+
+  postureRecovered: (params: {
+    session_id: string;
+    posture_level: number;
+    recovery_time_sec: number;
+  }) => trackEvent('posture_recovered', params),
+
+  widgetToggle: (params: { enabled: boolean }) =>
+    trackEvent('widget_toggle', params),
+
+  widgetVisibilityEnd: (params: { duration_sec: number; session_id?: string }) =>
+    trackEvent('widget_visibility_end', params),
+
+  notificationToggle: (params: { enabled: boolean }) =>
+    trackEvent('notification_toggle', params),
+
+  meaningfulUse: (params: { type: string }) =>
+    trackEvent('meaningful_use', params),
+} as const;
+

--- a/src/renderer/src/shared/lib/analytics/events.ts
+++ b/src/renderer/src/shared/lib/analytics/events.ts
@@ -5,7 +5,7 @@ export const AnalyticsEvents = {
     trackEvent('download_click', params),
 
   signUpComplete: (params: { user_id?: string }) =>
-    trackEvent('sign_up_complete', params),
+    trackEvent('sign_up_complete', params.user_id ? params : undefined),
 
   onboardingEnter: (params: { step: string }) =>
     trackEvent('onboarding_enter', params),
@@ -43,4 +43,3 @@ export const AnalyticsEvents = {
   meaningfulUse: (params: { type: string }) =>
     trackEvent('meaningful_use', params),
 } as const;
-

--- a/src/renderer/src/shared/lib/analytics/ga4.ts
+++ b/src/renderer/src/shared/lib/analytics/ga4.ts
@@ -1,0 +1,87 @@
+type Ga4Config = {
+  send_page_view?: boolean;
+  debug_mode?: boolean;
+  [key: string]: unknown;
+};
+
+type Ga4PageViewParams = {
+  page_path?: string;
+  page_location?: string;
+  page_title?: string;
+  [key: string]: unknown;
+};
+
+type GtagFn = {
+  (command: 'js', date: Date): void;
+  (command: 'config', measurementId: string, config?: Ga4Config): void;
+  (command: 'event', eventName: string, params?: Record<string, unknown>): void;
+};
+
+declare global {
+  interface Window {
+    dataLayer?: unknown[];
+    gtag?: GtagFn;
+  }
+}
+
+let activeMeasurementId: string | null = null;
+let initialized = false;
+
+function ensureGtagStub() {
+  if (typeof window === 'undefined') return;
+  window.dataLayer = window.dataLayer ?? [];
+  window.gtag =
+    window.gtag ??
+    ((...args: unknown[]) => {
+      window.dataLayer?.push(args);
+    });
+}
+
+function injectGtagScript(measurementId: string) {
+  if (typeof document === 'undefined') return;
+  const existing = document.querySelector<HTMLScriptElement>(
+    `script[data-ga4="gtag"][data-measurement-id="${measurementId}"]`,
+  );
+  if (existing) return;
+
+  const script = document.createElement('script');
+  script.async = true;
+  script.src = `https://www.googletagmanager.com/gtag/js?id=${encodeURIComponent(
+    measurementId,
+  )}`;
+  script.dataset.ga4 = 'gtag';
+  script.dataset.measurementId = measurementId;
+  document.head.appendChild(script);
+}
+
+export function initGA4(measurementId: string, config?: Ga4Config) {
+  if (!measurementId) return;
+  if (initialized && activeMeasurementId === measurementId) return;
+
+  activeMeasurementId = measurementId;
+  initialized = true;
+
+  ensureGtagStub();
+  injectGtagScript(measurementId);
+
+  window.gtag?.('js', new Date());
+  window.gtag?.('config', measurementId, {
+    send_page_view: false,
+    ...config,
+  });
+}
+
+export function trackPageView(params?: Ga4PageViewParams) {
+  if (!activeMeasurementId) return;
+  ensureGtagStub();
+
+  const page_location =
+    params?.page_location ??
+    (typeof window !== 'undefined' ? window.location.href : undefined);
+
+  window.gtag?.('event', 'page_view', {
+    page_location,
+    ...params,
+  });
+}
+

--- a/src/renderer/src/shared/lib/analytics/ga4.ts
+++ b/src/renderer/src/shared/lib/analytics/ga4.ts
@@ -105,5 +105,17 @@ export function trackEvent(
   if (!eventName) return;
   ensureGtagStub();
 
-  window.gtag?.('event', eventName, params);
+  const sanitizedParams = params
+    ? Object.fromEntries(
+        Object.entries(params).filter(([, value]) => value !== undefined),
+      )
+    : undefined;
+
+  window.gtag?.(
+    'event',
+    eventName,
+    sanitizedParams && Object.keys(sanitizedParams).length > 0
+      ? sanitizedParams
+      : undefined,
+  );
 }

--- a/src/renderer/src/shared/lib/analytics/ga4.ts
+++ b/src/renderer/src/shared/lib/analytics/ga4.ts
@@ -32,11 +32,16 @@ let initialized = false;
 function ensureGtagStub() {
   if (typeof window === 'undefined') return;
   window.dataLayer = window.dataLayer ?? [];
-  window.gtag =
-    window.gtag ??
-    ((...args: unknown[]) => {
-      window.dataLayer?.push(args);
-    });
+  if (window.gtag) return;
+
+  // Use the canonical gtag stub shape so gtag.js can seamlessly take over.
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const gtag = function (..._args: any[]) {
+    // eslint-disable-next-line prefer-rest-params
+    window.dataLayer?.push(arguments);
+  };
+
+  window.gtag = gtag as unknown as GtagFn;
 }
 
 function injectGtagScript(measurementId: string) {

--- a/src/renderer/src/shared/lib/analytics/ga4.ts
+++ b/src/renderer/src/shared/lib/analytics/ga4.ts
@@ -1,6 +1,7 @@
 type Ga4Config = {
   send_page_view?: boolean;
   debug_mode?: boolean;
+  user_id?: string;
   [key: string]: unknown;
 };
 
@@ -14,6 +15,7 @@ type Ga4PageViewParams = {
 type GtagFn = {
   (command: 'js', date: Date): void;
   (command: 'config', measurementId: string, config?: Ga4Config): void;
+  (command: 'set', params: Record<string, unknown>): void;
   (command: 'event', eventName: string, params?: Record<string, unknown>): void;
 };
 
@@ -71,6 +73,16 @@ export function initGA4(measurementId: string, config?: Ga4Config) {
   });
 }
 
+export function setGAUserId(userId: string) {
+  if (!activeMeasurementId) return;
+  if (!userId) return;
+  ensureGtagStub();
+
+  // Apply to subsequent events/config
+  window.gtag?.('set', { user_id: userId });
+  window.gtag?.('config', activeMeasurementId, { user_id: userId });
+}
+
 export function trackPageView(params?: Ga4PageViewParams) {
   if (!activeMeasurementId) return;
   ensureGtagStub();
@@ -85,3 +97,13 @@ export function trackPageView(params?: Ga4PageViewParams) {
   });
 }
 
+export function trackEvent(
+  eventName: string,
+  params?: Record<string, unknown>,
+) {
+  if (!activeMeasurementId) return;
+  if (!eventName) return;
+  ensureGtagStub();
+
+  window.gtag?.('event', eventName, params);
+}

--- a/src/renderer/src/shared/lib/analytics/index.ts
+++ b/src/renderer/src/shared/lib/analytics/index.ts
@@ -1,0 +1,3 @@
+export * from './ga4';
+export * from './events';
+

--- a/src/renderer/src/shared/types/vite-env.d.ts
+++ b/src/renderer/src/shared/types/vite-env.d.ts
@@ -1,3 +1,8 @@
 /// <reference types="vite/client" />
 /// <reference types="vite-plugin-svgr/client" />
 /// <reference types="../../preload/exposedInMainWorld" />
+
+interface ImportMetaEnv {
+  readonly VITE_GA_MEASUREMENT_ID?: string;
+  readonly VITE_GA_ENABLE_IN_DEV?: string;
+}

--- a/vite.config.mts
+++ b/vite.config.mts
@@ -12,6 +12,8 @@ const __dirname = path.dirname(__filename);
 // https://vitejs.dev/config/
 export default defineConfig({
   base: '/',
+  // Keep env files at repo root (/.env) even though Vite root is src/renderer
+  envDir: __dirname,
   root: 'src/renderer',
   plugins: [
     svgr(),


### PR DESCRIPTION
## GA4 이벤트/퍼널 로깅 추가

PMF/퍼널/리텐션 측정용으로 Electron renderer에 GA4(G-Measurement ID) 기반 이벤트 로깅을 추가했습니다.

### 주요 변경사항

- GA4 초기화/전송 유틸 추가
  - `src/renderer/src/shared/lib/analytics/ga4.ts`: gtag.js 로드, `page_view`/custom event 전송, `user_id` 세팅 지원
  - `src/renderer/src/shared/lib/analytics/events.ts`: `ga.md` 이벤트 스펙을 함수로 래핑해 이벤트명/파라미터 일관성 확보
- SPA 라우팅 `page_view` 전송
  - `src/renderer/src/app/providers/App.tsx`: `router.subscribe()` 기반으로 라우팅 변경마다 `page_view` 전송
- 퍼널/핵심 이벤트 연결(`ga.md` 기준)
  - 가입 완료: `sign_up_complete`
    - `src/renderer/src/entities/user/api/use-verify-email-mutation.ts`
    - `/auth/verify-email` 응답 `timestamp`를 `signupCompletedAt`으로 저장(리텐션 앵커)
    - `localStorage.clear()` 이후에도 `signupCompletedAt` 및 GA 플래그 보존
  - 온보딩 진입: `onboarding_enter`
    - `src/renderer/src/pages/onboarding-init-page/index.tsx`
  - 메인 진입/자세 이벤트
    - `measure_page_enter`, `bad_posture_enter`, `posture_recovered`
    - `src/renderer/src/pages/main-page/index.tsx`
  - 세션 시작/종료
    - `measure_start`, `first_measure_start`, `meaningful_use(7일 이후 1회)`
    - `src/renderer/src/entities/session/api/use-create-session-mutation.ts`
    - `measure_end`
    - `src/renderer/src/entities/session/api/use-stop-session-mutation.ts`
  - 위젯
    - `widget_toggle`, `widget_visibility_end`
    - `src/renderer/src/widgets/widget/lib/useWidget.ts`
  - 알림
    - `notification_toggle`
    - `src/renderer/src/features/notification/ui/NotificationModal.tsx`
- dev 환경에서 GA 확인 가능
  - `VITE_GA_ENABLE_IN_DEV=true`일 때 dev에서도 GA 활성화 + `debug_mode: true`
- env 로딩 수정
  - `vite.config.mts`: `envDir` 설정으로 repo 루트 `/.env`를 renderer에서도 인식
- DebugView/collect 전송 이슈 수정
  - canonical `gtag` stub 형태로 변경해서 `google-analytics.com/g/collect` 실제 전송 및 DebugView 동작

### 사용 방법

- `.env`
  - `VITE_GA_MEASUREMENT_ID=G-XXXXXXXXXX`
  - (로컬 확인 시) `VITE_GA_ENABLE_IN_DEV=true`

### 테스트

- `pnpm run typecheck:renderer` 통과
- `pnpm run lint:check` 통과(기존 warning만 존재)

### 참고

- `download_click`은 “다운로드 랜딩 페이지” 트리거가 이 repo에 없어 코드 연결은 제외(이벤트 스펙은 `ga.md`에 존재)
