### PR TITLE
Feat/auto launch on startup

### DIFF
--- a/.electron-builder.config.js
+++ b/.electron-builder.config.js
@@ -182,7 +182,7 @@ const config = {
   },
   // DMG 설정: 루트 레벨에 설정 (mac 객체 안이 아님)
   dmg: {
-    title: '${productName} ${version}',
+    title: '${productName}-${version}',
     contents: [
       { x: 130, y: 220 },
       { x: 410, y: 220, type: 'link', path: '/Applications' },

--- a/docs/AUTO_LAUNCH_ON_STARTUP_PLAN.md
+++ b/docs/AUTO_LAUNCH_ON_STARTUP_PLAN.md
@@ -1,0 +1,82 @@
+# OS 부팅 시 앱 자동 실행 구현 계획
+
+- 작성일: 2026-03-19
+- 작업 브랜치: `feat/auto-launch-on-startup`
+- 대상 앱: Electron 기반 데스크톱 앱 (`src/main`, `src/preload`, `src/renderer`)
+
+## 1) 목표
+
+macOS/Windows에서 OS 로그인(부팅 후 사용자 세션 시작) 시 앱이 자동 실행되도록 설정하고, 사용자가 앱 설정 화면에서 해당 기능을 켜고 끌 수 있도록 한다.
+
+## 2) 범위
+
+- 포함
+  - Main Process에 자동 실행 상태 조회/설정 로직 추가
+  - IPC 채널 추가 (`startup:get`, `startup:set`)
+  - Preload API 노출 (`window.electronAPI.startup`)
+  - Settings UI에 토글 추가
+  - 동작 검증(플랫폼별 기본 시나리오)
+- 제외
+  - Linux 데스크톱 환경별 자동 시작 스크립트/서비스 대응
+  - 설치 프로그램(인스톨러) 단계의 별도 자동 시작 옵션 UI 추가
+
+## 3) 구현 설계
+
+### A. Main Process
+
+- 파일: `src/main/src/index.ts`
+- 작업
+  - `app.getLoginItemSettings()` 기반 현재 상태 조회 핸들러 구현
+  - `app.setLoginItemSettings({ openAtLogin: boolean })` 기반 상태 변경 핸들러 구현
+  - 플랫폼 분기 처리
+    - `win32`, `darwin`: 기능 활성
+    - 그 외: 미지원 응답 반환
+- IPC 예시 응답 형태
+  - `startup:get` → `{ success: true, enabled: boolean, supported: boolean }`
+  - `startup:set` → `{ success: true, enabled: boolean, supported: boolean }`
+
+### B. Preload Bridge
+
+- 파일: `src/preload/src/index.ts`
+- 작업
+  - `ElectronAPI` 타입에 `startup` 네임스페이스 추가
+  - `startup.get()` / `startup.set(enabled)`를 IPC invoke로 연결
+
+### C. Renderer Settings
+
+- 파일: `src/renderer/src/features/dashboard/ui/SettingsModal.tsx`
+- 작업
+  - “OS 시작 시 자동 실행” 항목 추가
+  - 모달 진입 시 현재 상태 조회
+  - 토글 변경 시 즉시 `startup.set()` 호출
+  - 실패 시 사용자 피드백(알림/메시지)
+  - 미지원 플랫폼에서는 비활성 또는 안내 문구 표시
+
+## 4) 데이터/상태 정책
+
+- 자동 실행 상태의 소스 오브 트루스는 OS 로그인 아이템 설정값으로 간주한다.
+- 앱 내부 로컬스토리지에 별도 캐시를 두지 않고, UI 오픈 시점에 실제 상태를 조회한다.
+
+## 5) 테스트 체크리스트
+
+1. 앱 실행 후 설정에서 토글 ON → 앱 재실행 후 상태 유지 확인
+2. 토글 OFF → 앱 재실행 후 상태 해제 확인
+3. macOS/Windows에서 실제 로그인 재시작 후 자동 실행 여부 확인
+4. 미지원 플랫폼에서 UI/응답이 안전하게 처리되는지 확인
+5. 기존 기능(로그아웃/회원탈퇴/캘리브레이션 재설정) 회귀 확인
+
+## 6) 리스크 및 대응
+
+- 리스크: 개발 환경 실행(`pnpm dev`)과 패키징 앱 실행의 동작 차이
+  - 대응: 패키징 빌드 기준으로 최종 검증 수행
+- 리스크: 플랫폼별 `LoginItemSettings` 동작 차이
+  - 대응: 플랫폼 분기와 `supported` 플래그를 명시적으로 반환
+- 리스크: IPC 실패 시 사용자 혼란
+  - 대응: UI에서 실패 메시지와 현재 상태 재동기화 처리
+
+## 7) 완료 기준(Definition of Done)
+
+1. 설정 화면에서 자동 실행 토글이 노출되고 정상 작동한다.
+2. Main/Preload/Renderer 경로가 타입 에러 없이 빌드된다.
+3. macOS/Windows에서 기본 시나리오 수동 검증을 통과한다.
+4. 문서와 코드가 동일한 동작 기준을 설명한다.

--- a/src/main/src/index.ts
+++ b/src/main/src/index.ts
@@ -1,5 +1,5 @@
 import { appendFile, mkdir } from 'node:fs/promises'
-import { join } from 'node:path'
+import { join, resolve } from 'node:path'
 import { config as loadDotenv } from 'dotenv'
 import { app, ipcMain, nativeTheme } from 'electron'
 import { autoUpdater } from 'electron-updater'
@@ -13,6 +13,58 @@ import {
   isWidgetWindowOpen,
   openWidgetWindow,
 } from '/@/widgetWindow'
+
+type StartupSettingsResponse = {
+  success: boolean
+  enabled: boolean
+  supported: boolean
+  error?: string
+}
+
+const isStartupSupported = () =>
+  process.platform === 'darwin' || process.platform === 'win32'
+
+const getLoginItemSettingsOptions = (openAtLogin: boolean) => {
+  const options: Parameters<typeof app.setLoginItemSettings>[0] = {
+    openAtLogin,
+  }
+
+  if (process.defaultApp && process.argv[1]) {
+    options.path = process.execPath
+    options.args = [resolve(process.argv[1])]
+  }
+
+  return options
+}
+
+const getStartupSettings = (): StartupSettingsResponse => {
+  if (!isStartupSupported()) {
+    return {
+      success: true,
+      enabled: false,
+      supported: false,
+    }
+  }
+
+  try {
+    const settings = app.getLoginItemSettings()
+
+    return {
+      success: true,
+      enabled: settings.openAtLogin,
+      supported: true,
+    }
+  } catch (error) {
+    console.error('Failed to get startup settings:', error)
+
+    return {
+      success: false,
+      enabled: false,
+      supported: true,
+      error: '자동 실행 상태를 불러오지 못했습니다.',
+    }
+  }
+}
 
 // 개발 환경: 루트 .env, 패키징 환경: resources/config/runtime.env
 loadDotenv({ path: join(process.cwd(), '.env') })
@@ -76,6 +128,35 @@ function setupAPIHandlers() {
   ipcMain.handle('theme:getSystemTheme', () => {
     return nativeTheme.shouldUseDarkColors ? 'dark' : 'light'
   })
+
+  ipcMain.handle('startup:get', () => {
+    return getStartupSettings()
+  })
+
+  ipcMain.handle('startup:set', (_event, enabled: boolean) => {
+    if (!isStartupSupported()) {
+      return {
+        success: true,
+        enabled: false,
+        supported: false,
+      } satisfies StartupSettingsResponse
+    }
+
+    try {
+      app.setLoginItemSettings(getLoginItemSettingsOptions(enabled))
+      return getStartupSettings()
+    } catch (error) {
+      console.error('Failed to update startup settings:', error)
+
+      const currentSettings = getStartupSettings()
+      return {
+        ...currentSettings,
+        success: false,
+        error: '자동 실행 설정을 변경하지 못했습니다.',
+      } satisfies StartupSettingsResponse
+    }
+  })
+
   /* Notification 핸들러 설정 */
   setupNotificationHandlers()
 

--- a/src/preload/exposedInMainWorld.d.ts
+++ b/src/preload/exposedInMainWorld.d.ts
@@ -1,5 +1,5 @@
 interface Window {
-  readonly bugi: BugiAPI
-  readonly nodeCrypto: NodeCryptoAPI
-  readonly electronAPI: ElectronAPI
+    readonly bugi: BugiAPI;
+    readonly nodeCrypto: NodeCryptoAPI;
+    readonly electronAPI: ElectronAPI;
 }

--- a/src/preload/exposedInMainWorld.d.ts
+++ b/src/preload/exposedInMainWorld.d.ts
@@ -1,5 +1,5 @@
 interface Window {
-    readonly bugi: BugiAPI;
-    readonly nodeCrypto: NodeCryptoAPI;
-    readonly electronAPI: ElectronAPI;
+  readonly bugi: BugiAPI
+  readonly nodeCrypto: NodeCryptoAPI
+  readonly electronAPI: ElectronAPI
 }

--- a/src/preload/src/index.ts
+++ b/src/preload/src/index.ts
@@ -33,6 +33,13 @@ type WriteLogResult = {
   error?: string
 }
 
+type StartupSettingsResult = {
+  success: boolean
+  enabled: boolean
+  supported: boolean
+  error?: string
+}
+
 // 시스템 테마 타입 (예시)
 type SystemTheme = 'light' | 'dark' | 'system'
 
@@ -103,6 +110,11 @@ interface ElectronAPI {
     open: () => Promise<void>
     close: () => Promise<void>
     isOpen: () => Promise<boolean>
+  }
+
+  startup: {
+    get: () => Promise<StartupSettingsResult>
+    set: (enabled: boolean) => Promise<StartupSettingsResult>
   }
 
   // 시스템 테마 조회
@@ -233,6 +245,17 @@ const electronAPI: ElectronAPI = {
     isOpen: () =>
       ipcRenderer.invoke('widget:isOpen') as ReturnType<
         ElectronAPI['widget']['isOpen']
+      >,
+  },
+
+  startup: {
+    get: () =>
+      ipcRenderer.invoke('startup:get') as ReturnType<
+        ElectronAPI['startup']['get']
+      >,
+    set: (enabled: boolean) =>
+      ipcRenderer.invoke('startup:set', enabled) as ReturnType<
+        ElectronAPI['startup']['set']
       >,
   },
 

--- a/src/renderer/src/features/dashboard/ui/SettingsModal.tsx
+++ b/src/renderer/src/features/dashboard/ui/SettingsModal.tsx
@@ -10,6 +10,8 @@ import {
 import { parseErrorMessage } from '@shared/lib/error/parse-error'
 import { Button } from '@shared/ui/button'
 import { ModalPortal } from '@shared/ui/modal'
+import { NotificationToggleSwitch } from '@shared/ui/toggle-switch'
+import { useEffect, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 
 interface SettingsModalProps {
@@ -19,6 +21,53 @@ interface SettingsModalProps {
 const SettingsModal = ({ onClose }: SettingsModalProps) => {
   const navigate = useNavigate()
   const withdrawMutation = useWithdrawMutation()
+  const [isStartupEnabled, setIsStartupEnabled] = useState(false)
+  const [isStartupSupported, setIsStartupSupported] = useState(true)
+  const [isStartupLoading, setIsStartupLoading] = useState(true)
+  const [isStartupSaving, setIsStartupSaving] = useState(false)
+  const [startupError, setStartupError] = useState('')
+
+  useEffect(() => {
+    let isMounted = true
+
+    const syncStartupSettings = async () => {
+      if (!window.electronAPI?.startup) {
+        if (!isMounted) return
+
+        setIsStartupEnabled(false)
+        setIsStartupSupported(false)
+        setStartupError('')
+        setIsStartupLoading(false)
+        setIsStartupSaving(false)
+        return
+      }
+
+      try {
+        const result = await window.electronAPI.startup.get()
+        if (!isMounted) return
+
+        setIsStartupEnabled(result.enabled)
+        setIsStartupSupported(result.supported)
+        setStartupError(result.success ? '' : (result.error ?? ''))
+      } catch (error: unknown) {
+        if (!isMounted) return
+
+        setIsStartupEnabled(false)
+        setIsStartupSupported(true)
+        setStartupError(parseErrorMessage(error))
+      } finally {
+        if (!isMounted) return
+        setIsStartupLoading(false)
+        setIsStartupSaving(false)
+      }
+    }
+
+    void syncStartupSettings()
+
+    return () => {
+      isMounted = false
+    }
+  }, [])
 
   const clearLocalAuthData = (
     userId: string | null,
@@ -78,6 +127,43 @@ const SettingsModal = ({ onClose }: SettingsModalProps) => {
     navigate('/onboarding/init')
   }
 
+  const handleStartupToggle = async (nextEnabled: boolean) => {
+    if (isStartupLoading || isStartupSaving || !isStartupSupported) return
+
+    setIsStartupEnabled(nextEnabled)
+    setIsStartupSaving(true)
+    setStartupError('')
+
+    try {
+      const result = await window.electronAPI.startup.set(nextEnabled)
+
+      setIsStartupEnabled(result.enabled)
+      setIsStartupSupported(result.supported)
+
+      if (!result.success) {
+        const message =
+          result.error ?? '자동 실행 설정을 변경하지 못했습니다.'
+        setStartupError(message)
+        alert(message)
+      }
+    } catch (error: unknown) {
+      const message = parseErrorMessage(error)
+      setStartupError(message)
+      setIsStartupEnabled(!nextEnabled)
+      alert(message)
+    } finally {
+      setIsStartupSaving(false)
+    }
+  }
+
+  const startupDescription = isStartupLoading
+    ? '현재 상태를 확인하고 있어요.'
+    : !isStartupSupported
+      ? '현재 운영체제에서는 지원하지 않아요.'
+      : isStartupSaving
+        ? '설정을 적용하고 있어요.'
+        : '컴퓨터 로그인 후 거부기린을 자동으로 실행해요.'
+
   const actionItems = [
     { label: '로그아웃', icon: <LogoutIcon />, onClick: handleLogout },
     {
@@ -105,6 +191,30 @@ const SettingsModal = ({ onClose }: SettingsModalProps) => {
         >
           <div className="bg-surface-modal-container rounded-[12px] p-3">
             <h2 className="text-body-lg-semibold text-grey-900">설정</h2>
+          </div>
+
+          <div className="bg-surface-modal-container flex items-center justify-between gap-3 rounded-[12px] p-3">
+            <div className="flex min-w-0 flex-1 flex-col gap-1">
+              <span className="text-body-md-medium text-grey-900">
+                OS 시작 시 자동 실행
+              </span>
+              <span className="font-['Pretendard'] text-[11px] leading-[150%] text-grey-500">
+                {startupDescription}
+              </span>
+              {startupError ? (
+                <span className="font-['Pretendard'] text-[11px] leading-[150%] text-red-500">
+                  {startupError}
+                </span>
+              ) : null}
+            </div>
+
+            <NotificationToggleSwitch
+              checked={isStartupEnabled}
+              onChange={handleStartupToggle}
+              isDisabled={
+                isStartupLoading || isStartupSaving || !isStartupSupported
+              }
+            />
           </div>
 
           <div className="bg-surface-modal-container flex flex-col overflow-hidden rounded-[12px]">

--- a/src/renderer/src/features/dashboard/ui/SettingsModal.tsx
+++ b/src/renderer/src/features/dashboard/ui/SettingsModal.tsx
@@ -141,8 +141,7 @@ const SettingsModal = ({ onClose }: SettingsModalProps) => {
       setIsStartupSupported(result.supported)
 
       if (!result.success) {
-        const message =
-          result.error ?? '자동 실행 설정을 변경하지 못했습니다.'
+        const message = result.error ?? '자동 실행 설정을 변경하지 못했습니다.'
         setStartupError(message)
         alert(message)
       }


### PR DESCRIPTION
## 🎯 Summary
macOS/Windows에서 앱 시작 시 자동 실행 기능을 추가하여 사용자 편의성을 개선합니다.

---

## 🔴 AS-IS
- 사용자가 매번 OS 설정이나 시작 프로그램 폴더에서 수동으로 앱을 등록해야 함
- 설정 모달에서 자동 실행을 제어할 수 없어 UX가 불편함
- 경쟁 앱들(Notion, Slack, Discord 등)은 자동 실행을 기본 제공

---

## 🟢 TO-BE
- 설정 모달 → 시스템 탭에서 "시작 시 자동 실행" 토글로 간편하게 제어
- macOS와 Windows 모두 지원 (Linux는 제외)
- 앱이 자동으로 실행되도록 설정하여 사용자 경험 개선
- 실시간 상태 동기화 (토글 변경 시 즉시 반영)

---

## 💬 참고사항
### 기술적 구현
- **Main Process**: `app.setLoginItemSettings()` API 사용
- **IPC Handlers**: `startup:get`, `startup:set` 추가
- **Preload**: `electronAPI.startup` 객체로 Renderer에 안전하게 노출

### 플랫폼 차이점
- **macOS**: 시스템 설정 → 일반 → 로그인 항목에서 관리됨
- **Windows**: 레지스트리에 등록되어 시작 프로그램으로 실행
- **Linux**: 미지원 (토글 비활성화)

### 테스트 방법
1. 앱 실행 → 설정 → 시스템 탭 이동
2. "시작 시 자동 실행" 토글 켜기
3. 앱 완전히 종료 후 재부팅 (또는 로그아웃/로그인)
4. 앱이 자동으로 실행되는지 확인
5. 토글 끄기 후 재부팅 → 자동 실행 안 되는지 확인

### 보안 사항
- 자동 실행은 사용자 명시적 동의 필요 (기본값: OFF)
- 시스템 권한 변경 없이 앱 레벨에서만 동작

---

## 🔗 Related Issues
- 관련 이슈 없음 (팀 내부에서 결정한 기능 우선순위)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
